### PR TITLE
Add shellcheck GitHub action

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,4 +12,5 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         scandir: './usr/local/bin'
-        severity: error
+      env:
+        SHELLCHECK_OPTS: -e SC2034 -e SC2154

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,3 +12,4 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         scandir: './usr/local/bin'
+        severity: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+
+name: 'Analyse shell scripts'
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        scandir: './usr/local/bin'


### PR DESCRIPTION
Adds a GitHub action to the repository. Whenever there is a Git push or pull request, it will analyze the shell scripts in `usr/local/bin` with Shellcheck.

![github action check](https://user-images.githubusercontent.com/39676098/140635117-2c607edc-2626-47b4-b397-348fe400a1ab.png)

It will display either a green checkmark or a red cross (shown above) whether or not the tests have passed or failed. You can click on it to see the errors/warnings that popped up:

![ShellCheck logs](https://user-images.githubusercontent.com/39676098/140635156-057922e9-481f-4424-adaf-1fed0b0c2bd3.png)
