### PR TITLE
Resolve warnings from ShellCheck GitHub action

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         scandir: './usr/local/bin'
       env:
-        SHELLCHECK_OPTS: -e SC2034 -e SC2154
+        SHELLCHECK_OPTS: -x -e SC2034 -e SC2154

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         scandir: './usr/local/bin'
       env:
-        SHELLCHECK_OPTS: -x -e SC2034 -e SC2154
+        SHELLCHECK_OPTS: -x -e SC2034 -e SC2154 -e SC1091

--- a/usr/local/bin/color-gpick
+++ b/usr/local/bin/color-gpick
@@ -7,7 +7,7 @@ color=$(gpick -pso --no-newline)
 main() {
 	if [[ "$color" ]]; then
 		# copy color code to clipboard
-		echo $color | tr -d "\n" | xclip -selection clipboard
+		echo "$color" | tr -d "\n" | xclip -selection clipboard
 		# notify about it
 		dunstify -u low --replace=69 -i /usr/share/icons/Papirus-Dark/symbolic/status/notification-symbolic.svg "$color, copied to clipboard."
 	fi

--- a/usr/local/bin/lock
+++ b/usr/local/bin/lock
@@ -15,7 +15,7 @@ MAGENTA="#B07190"
 CYAN="#4DD0E1"
 WHITE="#FFFFFF"
 
-TOTD=`fortune -n 90 -s | head -n 1`
+TOTD=$(fortune -n 90 -s | head -n 1)
 
 ## Exec	-----------------
 i3lock \

--- a/usr/local/bin/lock
+++ b/usr/local/bin/lock
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 
 ## Get colors -----------------
 source colors

--- a/usr/local/bin/powermenu
+++ b/usr/local/bin/powermenu
@@ -12,6 +12,6 @@ case "$choice" in
   1) systemctl suspend          ;;
   2) poweroff			;;
   3) reboot 			;;
-  4) pkill -KILL -u $USER &	;;
+  4) pkill -KILL -u "$USER" &	;;
 esac
 

--- a/usr/local/bin/volume
+++ b/usr/local/bin/volume
@@ -4,7 +4,7 @@
 
 # Get Volume
 get_volume() {
-	volume=`amixer get Master | tail -n1 | awk -F ' ' '{print $5}' | tr -d '[]'`
+	volume=$(amixer get Master | tail -n1 | awk -F ' ' '{print $5}' | tr -d '[]')
 	echo "$volume"
 }
 
@@ -37,7 +37,7 @@ dec_volume() {
 
 # Toggle Mute
 toggle_mute() {
-	status=`amixer get Master | tail -n1 | grep -wo 'on'`
+    status=$(amixer get Master | tail -n1 | grep -wo 'on')
 
 	if [[ "$status" == "on" ]]; then
 		amixer set Master toggle && dunstify -u low --replace=69 -i '/usr/share/icons/Papirus-Dark/symbolic/status/audio-volume-muted-symbolic.svg' "Mute"

--- a/usr/local/bin/ytd
+++ b/usr/local/bin/ytd
@@ -13,9 +13,9 @@ if [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "  -s, --search    Searches for the video you're looking for."
 
 elif [[ $1 == "--mp3" ]]; then
-	youtube-dl -x --audio-format mp3 --prefer-ffmpeg $2
+	youtube-dl -x --audio-format mp3 --prefer-ffmpeg "$2"
 elif [[ "$1" == "--mp4" ]]; then
-	youtube-dl -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio" --merge-output-format mp4 $2
+	youtube-dl -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio" --merge-output-format mp4 "$2"
 elif [[ "$1" == "-s" || "$1" == "--search" ]]; then
     youtube-dl "ytsearch1: $2"
 fi


### PR DESCRIPTION
Resolves the rest of the warnings from the GitHub action by either changing the script or disabling the warning. The status should now be green instead of red.